### PR TITLE
fix: Fixes index out of range on empty args

### DIFF
--- a/WSDLToTypescriptProxy/Infras/ArgsParser.cs
+++ b/WSDLToTypescriptProxy/Infras/ArgsParser.cs
@@ -8,7 +8,7 @@ namespace WSDLToTypescriptProxy.Infras
         {
             parsedArgs = new Dictionary<ArgType, string>();
 
-            if (args.Length != 1 && args.Length != 3 && args[1] != "/o")
+            if (args.Length == 0 || (args.Length != 1 && args.Length != 3 && args[1] != "/o"))
                 return false;
 
             var remoteUri = string.Empty;


### PR DESCRIPTION
This will fix the index out of range caused from trying to parse the last comparison in the if statement ( args[1]) in the case that the user passed no arguments. The short-circuit evaluation in the change will allow the case of a zero length argument array to immediately drop to the return statement, bypassing the additional checks.